### PR TITLE
Debts MVP - redistribute the pot

### DIFF
--- a/oldabe/models.py
+++ b/oldabe/models.py
@@ -33,11 +33,14 @@ class Debt:
         return self.amount - self.amount_paid
 
 
+# Individual advances can have a positive or negative amount (to
+# indicate an actual advance payment, or a drawn down advance).
+# To find the current advance amount for a given contributor,
+# sum all of their existing Advance objects.
 @dataclass
 class Advance:
     email: str = None
     amount: Decimal = 0
-
     payment_file: str = None
     commit_hash: str = None
     created_at: datetime = field(default_factory=datetime.utcnow)

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -468,7 +468,7 @@ def create_debts(amounts_owed, unpayable_contributors, payment_file):
     debts = []
     commit_hash = get_git_revision_short_hash()
     for email, amount in unpayable_amounts_owed.items():
-        debt = Debt(email, amount, payment_file=payment_file, commit_hash=commit_hash))
+        debt = Debt(email, amount, payment_file=payment_file, commit_hash=commit_hash)
         debts.append(debt)
 
     return debts
@@ -515,10 +515,11 @@ def get_amounts_owed(total_amount, attributions):
             for email, share in attributions.items()}
 
 
-# TODO (turn into doc string): finally, redistribute the pot over all payable contributors
-# go through attributions for payable people and redistribute pot accordingly
-# create advances for each of those amounts, and add the amount to amounts_owed
 def redistribute_pot(redistribution_pot, attributions, unpayable_contributors, payment_file, amounts_owed):
+    # Redistribute the pot of remaining money over all payable contributors, according to attributions
+    # share (normalized to 100%). Create advances for those amounts (because they are in excess
+    # of the amount owed to each contributor from the original payment) and add the amounts to the
+    # amounts_owed dictionary to keep track of the full amount we are about to pay everyone.
     fresh_advances = []
     normalized_payable_attributions = normalize(
         {email: share for email, share in attributions.items() if email not in unpayable_contributors}

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -408,6 +408,12 @@ def read_advances():
 
 
 def get_sum_of_advances_by_contributor():
+    """
+    Sum all Advance objects for each contributor to get the total amount
+    that they currently have in advances and have not yet drawn down.
+    Return a dictionary with the contributor's email as the key and the
+    their advance amount as the value.
+    """
     all_advances = read_advances()
     advance_totals = {email: sum(a.amount for a in advances)
                       for email, advances
@@ -514,10 +520,12 @@ def get_amounts_owed(total_amount, attributions):
 
 
 def redistribute_pot(redistribution_pot, attributions, unpayable_contributors, payment_file, amounts_owed):
-    # Redistribute the pot of remaining money over all payable contributors, according to attributions
-    # share (normalized to 100%). Create advances for those amounts (because they are in excess
-    # of the amount owed to each contributor from the original payment) and add the amounts to the
-    # amounts_owed dictionary to keep track of the full amount we are about to pay everyone.
+    """
+    Redistribute the pot of remaining money over all payable contributors, according to attributions
+    share (normalized to 100%). Create advances for those amounts (because they are in excess
+    of the amount owed to each contributor from the original payment) and add the amounts to the
+    amounts_owed dictionary to keep track of the full amount we are about to pay everyone.
+    """
     fresh_advances = []
     normalized_payable_attributions = normalize(
         {email: share for email, share in attributions.items() if email not in unpayable_contributors}

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -515,22 +515,23 @@ def get_amounts_owed(total_amount, attributions):
             for email, share in attributions.items()}
 
 
-def distribute_remaining_amount(remaining_amount, truncated_payable_attributions, payment):
-    """
-    After paying off debts, distribute remaining amount to payable contributors
-    in the attributions file, by renormalizing after excluding unpayable
-    contributors.
-    """
-    amounts_owed = get_amounts_owed(remaining_amount, truncated_payable_attributions)
-    remainder_attributions = normalize(truncated_payable_attributions)
-    advances
-    transactions = generate_transactions(
-        remaining_amount, remainder_attributions, payment.file, commit_hash
+# TODO (turn into doc string): finally, redistribute the pot over all payable contributors
+# go through attributions for payable people and redistribute pot accordingly
+# create advances for each of those amounts, and add the amount to amounts_owed
+def redistribute_pot(redistribution_pot, attributions, unpayable_contributors, payment_file, amounts_owed):
+    fresh_advances = []
+    normalized_payable_attributions = normalize(
+        {email: share for email, share in attributions.items() if email not in unpayable_contributors}
     )
+    for email, share in normalized_payable_attributions.items():
+        advance_amount = redistribution_pot * share
+        fresh_advances.append(Advance(email=email,
+                                      amount=advance_amount,
+                                      payment_file=payment_file,
+                                      commit_hash=get_git_revision_short_hash()))
+        amounts_owed[email] += advance_amount
 
-    commit_hash = get_git_revision_short_hash()
-
-    return transactions
+    return fresh_advances
 
 
 def draw_down_advances(amounts_owed, unpayable_contributors):
@@ -590,8 +591,8 @@ def distribute_payment(payment, attributions):
             drawdown_amount = max(advance_total - amount_owed, 0)
             if drawdown_amount:
                 negative_advance = Advance(email=email,
-                                           amount=-drawdown_amount # note minus sign
-                                           payment_file=payment.payment_file
+                                           amount=-drawdown_amount, # note minus sign
+                                           payment_file=payment.payment_file,
                                            commit_hash=commit_hash)
                 negative_advances.append(negative_advance)
                 amounts_owed[email] -= drawdown_amount
@@ -600,19 +601,14 @@ def distribute_payment(payment, attributions):
         # and that's why we take the absolute value here
         redistribution_pot += sum(abs(a.amount) for a in negative_advances)
 
-        # TODO: finally, redistribute the pot over all payable contributors
-        # go through attributions for payable people and redistribute pot accordingly
-        # create advances for each of those amounts, and add the amount to amounts_owed
-        # later, generate transactions from the final amounts in amounts_owed
-
-        # this will now need to be updated to reflect the above comment
-        # will be almost the same as before except that remaining_amount will be
-        # redistribution_pot instead.
-        equity_transactions = (distribute_remaining_amount(redistribution_pot,
-                                                           truncated_payable_attributions,
-                                                           payment)
-                               if remaining_amount else [])
-
+        # redistribute the pot over all payable contributors - produce fresh advances and add to amounts owed
+        fresh_advances = redistribute_pot(redistribution_pot,
+                                          attributions,
+                                          unpayable_contributors,
+                                          payment.payment_file,
+                                          amounts_owed)
+        # TODO - generate transactions from the final amounts in amounts_owed
+        
     debts = updated_debts + fresh_debts
     transactions = equity_transactions + debt_transactions
 

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -407,8 +407,6 @@ def read_advances():
     return advances
 
 
-# get_advance_total_by_contributor
-# get_advance_sum_by_contributor/email/user
 def get_sum_of_advances_by_contributor():
     all_advances = read_advances()
     advance_totals = {email: sum(a.amount for a in advances)


### PR DESCRIPTION
### Summary of Changes
- Implement logic for `redistribute_pot` to redistribute the money from creating fresh debts and drawing down existing advances.
- Update TODOs and doc strings. I propose that at some point we move some functions out of money_in and into a utils or helpers file, just to clear up space and make the main module easier to navigate. I started marking some of the utility functions.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
